### PR TITLE
Use limits on truncnorm.rvs to avoid generating invalid points

### DIFF
--- a/mr_forecast.py
+++ b/mr_forecast.py
@@ -253,7 +253,7 @@ def Rstat2M(mean, std, unit='Earth', sample_size=1e3, grid_size=1e3, classify = 
 		print "Input unit must be 'Earth' or 'Jupiter'. Using 'Earth' as default."
 
 	# draw samples
-	radius = truncnorm.rvs( (0.-mean)/std, np.inf, loc=mean, scale=std, size=sample_size)	
+	radius = truncnorm.rvs( (0.1-mean)/std, (1e2-mean)/std, loc=mean, scale=std, size=sample_size)	
 	if classify == 'Yes':
 		mass = Rpost2M(radius, 'Earth', grid_size, classify='Yes')
 	else:


### PR DESCRIPTION
Mstat2R uses the limits of the truncated normal distribution to avoid generating points outside the range supported by Mpost2R. This patch does the equivalent for Rstat2M.

While this prevents the errors, I'm not sure if doing this truncation is necessarily the correct way to go.
